### PR TITLE
PDFastSimANN optimization: batch processing, PDFastSimPAR improvements, and TensorFlow caching 

### DIFF
--- a/larsimdnn/PhotonPropagation/PDFastSimANN_module.cc
+++ b/larsimdnn/PhotonPropagation/PDFastSimANN_module.cc
@@ -74,7 +74,7 @@ namespace phot {
   private:
     const bool fDoSlowComponent;
     const bool fUseLitePhotons;
-    const size_t fBatchSize;  // KEPT: Configurable batch size for processing
+    const size_t fBatchSize; // KEPT: Configurable batch size for processing
     art::InputTag simTag;
     std::unique_ptr<ScintTime> fScintTime; //Tool to retrive timinig of scintillation
     std::unique_ptr<TFLoader>
@@ -84,18 +84,17 @@ namespace phot {
     std::map<int, int> PDChannelToSOCMap; //Where each OpChan is.
     int nOpChannels;                      //Number of optical detector
 
-
     // Method matching PDFastSimPAR optimization
     // This method uses OBTRHelper map pattern and batches photon additions
     void SimpleAddOpDetBTR(
-      std::map<int, sim::OBTRHelper>& opbtr_helper,  // Map instead of vector for O(1) access
+      std::map<int, sim::OBTRHelper>& opbtr_helper, // Map instead of vector for O(1) access
       std::map<int, int>& ChannelMap,
       size_t channel,
       int trackID,
       int time,
       double pos[3],
       double edeposit,
-      int num_photons = 1);  // Support adding multiple photons at once
+      int num_photons = 1); // Support adding multiple photons at once
 
     // Process a batch of energy deposits (Memory Optimization)
     void ProcessEnergyDepositBatch(
@@ -104,7 +103,7 @@ namespace phot {
       size_t end_idx,
       std::vector<sim::SimPhotons>& photonCollection,
       std::vector<sim::SimPhotonsLite>& photonLiteCollection,
-      std::map<int, sim::OBTRHelper>& opbtr_helper,  // from vector to map
+      std::map<int, sim::OBTRHelper>& opbtr_helper, // from vector to map
       CLHEP::RandPoissonQ& randpoisphot,
       float vis_scale);
   };
@@ -114,7 +113,7 @@ namespace phot {
     : art::EDProducer{pset}
     , fDoSlowComponent(pset.get<bool>("DoSlowComponent", true))
     , fUseLitePhotons(art::ServiceHandle<sim::LArG4Parameters const>()->UseLitePhotons())
-    , fBatchSize(pset.get<size_t>("BatchSize", 50000))  // Batch size optimization
+    , fBatchSize(pset.get<size_t>("BatchSize", 50000)) // Batch size optimization
     , simTag{pset.get<art::InputTag>("SimulationLabel")}
     , fScintTime{art::make_tool<ScintTime>(pset.get<fhicl::ParameterSet>("ScintTimeTool"))}
     , fTFGenerator{art::make_tool<TFLoader>(pset.get<fhicl::ParameterSet>("TFLoaderTool"))}
@@ -131,7 +130,8 @@ namespace phot {
         pset,
         "SeedScintTime"))
   {
-    std::cout << "PDFastSimANN Module Construct (with batch processing + OBTRHelper optimization, batch size = "
+    std::cout << "PDFastSimANN Module Construct (with batch processing + OBTRHelper optimization, "
+                 "batch size = "
               << fBatchSize << ")" << std::endl;
 
     if (fUseLitePhotons) {
@@ -167,18 +167,18 @@ namespace phot {
 
     return;
   }
-  
+
   //......................................................................
   void PDFastSimANN::produce(art::Event& event)
   {
     std::cout << "PDFastSimANN Module Producer..." << std::endl;
-    
+
     CLHEP::RandPoissonQ randpoisphot{fPhotonEngine};
 
     std::unique_ptr<std::vector<sim::SimPhotons>> phot(new std::vector<sim::SimPhotons>);
     std::unique_ptr<std::vector<sim::SimPhotonsLite>> phlit(new std::vector<sim::SimPhotonsLite>);
     std::unique_ptr<std::vector<sim::OpDetBacktrackerRecord>> opbtr(
-								    new std::vector<sim::OpDetBacktrackerRecord>);
+      new std::vector<sim::OpDetBacktrackerRecord>);
 
     auto& photonCollection(*phot);
     auto& photonLiteCollection(*phlit);
@@ -208,12 +208,12 @@ namespace phot {
     int num_points = edeps->size();
     float vis_scale = 1.0;
 
-    std::cout << "Processing " << num_points << " energy deposits in batches of "
-              << fBatchSize << std::endl;
+    std::cout << "Processing " << num_points << " energy deposits in batches of " << fBatchSize
+              << std::endl;
 
     // OBTRHelper map for efficient backtracker record construction
     std::map<int, sim::OBTRHelper> opbtr_helper;
-    
+
     // Initialize PDChannelToSOCMap with -1 for all channels
     PDChannelToSOCMap.clear();
     for (int i = 0; i < nOpChannels; i++) {
@@ -223,9 +223,9 @@ namespace phot {
     // Process in batches
     for (size_t batch_start = 0; batch_start < edeps->size(); batch_start += fBatchSize) {
       size_t batch_end = std::min(batch_start + fBatchSize, edeps->size());
-      
-      std::cout << "Processing batch " << (batch_start / fBatchSize + 1)
-                << " (deposits " << batch_start << " to " << batch_end << ")" << std::endl;
+
+      std::cout << "Processing batch " << (batch_start / fBatchSize + 1) << " (deposits "
+                << batch_start << " to " << batch_end << ")" << std::endl;
 
       ProcessEnergyDepositBatch(*edeps,
                                 batch_start,
@@ -238,7 +238,7 @@ namespace phot {
     }
 
     std::cout << "PDFastSimANN module produced " << num_points << " images..." << std::endl;
-    
+
     // Convert helper map to final vector only at the end
     if (fUseLitePhotons) {
       for (auto& iopbtr : opbtr_helper) {
@@ -268,12 +268,12 @@ namespace phot {
     size_t end_idx,
     std::vector<sim::SimPhotons>& photonCollection,
     std::vector<sim::SimPhotonsLite>& photonLiteCollection,
-    std::map<int, sim::OBTRHelper>& opbtr_helper,  // map instead of vector
+    std::map<int, sim::OBTRHelper>& opbtr_helper, // map instead of vector
     CLHEP::RandPoissonQ& randpoisphot,
     float vis_scale)
   {
     size_t batch_size = end_idx - start_idx;
-    
+
     // Prepare input positions for this batch only
     std::vector<std::array<double, 3>> positions;
     positions.reserve(batch_size);
@@ -315,7 +315,7 @@ namespace phot {
         if (visibleFraction == 0.0) { continue; }
 
         if (fUseLitePhotons) {
-	  // New optimized pattern - batch photons by time
+          // New optimized pattern - batch photons by time
           // This reduces O(millions) of function calls to O(thousands)
           std::map<int, int> temp_photon_times_fast;
           std::map<int, int> temp_photon_times_slow;
@@ -327,7 +327,7 @@ namespace phot {
               fScintTime->GenScintTime(true, fScintTimeEngine);
               auto time = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime());
               ++photonLiteCollection[channel].DetectedPhotons[time];
-              ++temp_photon_times_fast[time];  // Batch by time
+              ++temp_photon_times_fast[time]; // Batch by time
             }
           }
 
@@ -338,7 +338,7 @@ namespace phot {
               fScintTime->GenScintTime(false, fScintTimeEngine);
               auto time = static_cast<int>(edepi.StartT() + fScintTime->GetScintTime());
               ++photonLiteCollection[channel].DetectedPhotons[time];
-              ++temp_photon_times_slow[time];  // Batch by time
+              ++temp_photon_times_slow[time]; // Batch by time
             }
           }
 
@@ -346,13 +346,13 @@ namespace phot {
           // Instead of adding photons one-by-one, we add all photons at each time together
           // This is the key optimization that reduces function calls dramatically
           for (auto const& [time, nphotons] : temp_photon_times_fast) {
-            SimpleAddOpDetBTR(opbtr_helper, PDChannelToSOCMap, channel, 
-                            trackID, time, pos, edeposit, nphotons);
+            SimpleAddOpDetBTR(
+              opbtr_helper, PDChannelToSOCMap, channel, trackID, time, pos, edeposit, nphotons);
           }
-          
+
           for (auto const& [time, nphotons] : temp_photon_times_slow) {
-            SimpleAddOpDetBTR(opbtr_helper, PDChannelToSOCMap, channel, 
-                            trackID, time, pos, edeposit, nphotons);
+            SimpleAddOpDetBTR(
+              opbtr_helper, PDChannelToSOCMap, channel, trackID, time, pos, edeposit, nphotons);
           }
         }
         else {
@@ -393,15 +393,14 @@ namespace phot {
   // 1. Uses map instead of vector for O(1) access by channel
   // 2. Uses OBTRHelper which has optimized internal map operations
   // 3. Supports adding multiple photons at once (num_photons parameter)
-  void PDFastSimANN::SimpleAddOpDetBTR(
-				       std::map<int, sim::OBTRHelper>& opbtr_helper,
-				       std::map<int, int>& ChannelMap,
-				       size_t channel,
-				       int trackID,
-				       int time,
-				       double pos[3],
-				       double edeposit,
-				       int num_photons)
+  void PDFastSimANN::SimpleAddOpDetBTR(std::map<int, sim::OBTRHelper>& opbtr_helper,
+                                       std::map<int, int>& ChannelMap,
+                                       size_t channel,
+                                       int trackID,
+                                       int time,
+                                       double pos[3],
+                                       double edeposit,
+                                       int num_photons)
   {
     // Check if this is the first time we're seeing this channel
     if (opbtr_helper.find(channel) == opbtr_helper.end()) {
@@ -409,14 +408,14 @@ namespace phot {
       ChannelMap[channel] = opbtr_helper.size();
       opbtr_helper.emplace(channel, channel);
     }
-    
+
     // Add photons directly to the helper's internal map
     // This is much faster than the old method which required:
     // 1. Creating a temporary OpDetBacktrackerRecord
     // 2. Adding photons one-by-one to the temp record
     // 3. Merging the temp record into the main collection
     opbtr_helper.at(channel).AddScintillationPhotonsToMap(
-							  trackID, time, num_photons, pos, edeposit);
+      trackID, time, num_photons, pos, edeposit);
   }
 
 } // namespace

--- a/larsimdnn/PhotonPropagation/PDFastSimANN_module.cc
+++ b/larsimdnn/PhotonPropagation/PDFastSimANN_module.cc
@@ -114,7 +114,7 @@ namespace phot {
     : art::EDProducer{pset}
     , fDoSlowComponent(pset.get<bool>("DoSlowComponent", true))
     , fUseLitePhotons(art::ServiceHandle<sim::LArG4Parameters const>()->UseLitePhotons())
-    , fBatchSize(pset.get<size_t>("BatchSize", 50000))  // KEPT: Batch size optimization
+    , fBatchSize(pset.get<size_t>("BatchSize", 50000))  // Batch size optimization
     , simTag{pset.get<art::InputTag>("SimulationLabel")}
     , fScintTime{art::make_tool<ScintTime>(pset.get<fhicl::ParameterSet>("ScintTimeTool"))}
     , fTFGenerator{art::make_tool<TFLoader>(pset.get<fhicl::ParameterSet>("TFLoaderTool"))}

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP.h
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP.h
@@ -43,7 +43,7 @@ namespace phot {
 
     tensorflow::SavedModelBundleLite* modelbundle;
 
-    tensorflow::Status status; 
+    tensorflow::Status status;
 
     // Cached tensors to avoid repeated allocation/deallocation
     // These tensors are reused across all batches to prevent TensorFlow
@@ -52,7 +52,7 @@ namespace phot {
     tensorflow::Tensor cached_pos_x;
     tensorflow::Tensor cached_pos_y;
     tensorflow::Tensor cached_pos_z;
-    int cached_batch_size = 0;  // Track current tensor size
+    int cached_batch_size = 0; // Track current tensor size
   };
 }
 #endif

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP.h
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP.h
@@ -44,6 +44,15 @@ namespace phot {
     tensorflow::SavedModelBundleLite* modelbundle;
 
     tensorflow::Status status; // ✔️ Fully correct
+
+    // ADDED: Cached tensors to avoid repeated allocation/deallocation
+    // These tensors are reused across all batches to prevent TensorFlow
+    // from accumulating memory. Each event processes ~50 batches, so without
+    // this optimization, for example, TF would cache approximately 150+ tensor allocations after 3 events.
+    tensorflow::Tensor cached_pos_x;
+    tensorflow::Tensor cached_pos_y;
+    tensorflow::Tensor cached_pos_z;
+    int cached_batch_size = 0;  // Track current tensor size
   };
 }
 #endif

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP.h
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP.h
@@ -43,9 +43,9 @@ namespace phot {
 
     tensorflow::SavedModelBundleLite* modelbundle;
 
-    tensorflow::Status status; // ✔️ Fully correct
+    tensorflow::Status status; 
 
-    // ADDED: Cached tensors to avoid repeated allocation/deallocation
+    // Cached tensors to avoid repeated allocation/deallocation
     // These tensors are reused across all batches to prevent TensorFlow
     // from accumulating memory. Each event processes ~50 batches, so without
     // this optimization, for example, TF would cache approximately 150+ tensor allocations after 3 events.

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP_tool.cc
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP_tool.cc
@@ -17,14 +17,20 @@ namespace phot {
   //......................................................................
   void TFLoaderMLP::Initialization()
   {
+    std::cout << "DEBUG:  TFLoaderMLP::Initialization() called" << std::endl;  
+    
     int num_input = int(InputsName.size());
     if (num_input != 3) {
       std::cout << "Input name error! exit!" << std::endl;
       return;
     }
+
+     std::cout << "DEBUG: Looking for model: " << ModelName << std::endl;
+     
     std::string GraphFileWithPath;
     cet::search_path sp("FW_SEARCH_PATH");
     if (!sp.find_file(ModelName, GraphFileWithPath)) {
+      std::cout << "DEBUG:  MODEL FILE NOT FOUND!" << std::endl;  
       throw cet::exception("TFLoaderMLP")
         << "In larrecodnn:phot::TFLoaderMLP: Failed to load SavedModel in : " << sp.to_string()
         << "\n";
@@ -62,42 +68,51 @@ namespace phot {
   {
     if (status.ok()) {
       std::cout << "Close TF session." << std::endl;
-      //            session->Close();
     }
 
+    // ADDED: Clear cached tensors before deleting session
+    // This ensures tensor memory is released before session shutdown
+    cached_batch_size = 0;
+    cached_pos_x = tensorflow::Tensor();
+    cached_pos_y = tensorflow::Tensor();
+    cached_pos_z = tensorflow::Tensor();
+    
     delete modelbundle;
-
-    //        delete session;
     return;
   }
-
+  
   //......................................................................
   void TFLoaderMLP::Predict(std::vector<double> pars)
   {
-    //std::cout << "TFLoader MLP:: Predicting... " << std::endl;
+    // std::cout << "TFLoader MLP:: Predicting... " << std::endl;
+    // Single point prediction (not used in batch processing) 
     int num_input = int(pars.size());
     if (num_input != 3) {
       std::cout << "Input parameter error! exit!" << std::endl;
       return;
     }
-    //Clean prediction
+    
+    // Clean prediction
     std::vector<double>().swap(prediction);
-
-    //Define inputs
+    
+    // Define inputs for single prediction (this method is not optimized)
     tensorflow::Tensor pos_x(tensorflow::DT_FLOAT, tensorflow::TensorShape({1, 1}));
     tensorflow::Tensor pos_y(tensorflow::DT_FLOAT, tensorflow::TensorShape({1, 1}));
     tensorflow::Tensor pos_z(tensorflow::DT_FLOAT, tensorflow::TensorShape({1, 1}));
+
     auto dst_x = pos_x.flat<float>().data();
     auto dst_y = pos_y.flat<float>().data();
     auto dst_z = pos_z.flat<float>().data();
+    
     copy_n(pars.begin(), 1, dst_x);
     copy_n(pars.begin() + 1, 1, dst_y);
     copy_n(pars.begin() + 2, 1, dst_z);
+    
     std::vector<std::pair<std::string, tensorflow::Tensor>> inputs = {
       {InputsName[0], pos_x}, {InputsName[1], pos_y}, {InputsName[2], pos_z}};
     //Define outps
     std::vector<tensorflow::Tensor> outputs;
-
+    
     //Run the session
     status = modelbundle->GetSession()->Run(inputs, {OutputName}, {}, &outputs);
     //        status = session->Run(inputs, {OutputName}, {}, &outputs);
@@ -105,11 +120,11 @@ namespace phot {
       std::cout << status.ToString() << std::endl;
       return;
     }
-
+    
     //Grab the outputs
     unsigned int pdr = outputs[0].shape().dim_size(1);
     //std::cout << "TFLoader MLP::Num of optical channels: " << pdr << std::endl;
-
+    
     for (unsigned int i = 0; i < pdr; i++) {
       double value = outputs[0].flat<float>()(i);
       //std::cout << value << ", ";
@@ -119,7 +134,7 @@ namespace phot {
     return;
   }
 
-  //New batch prediction function---
+  // New batch prediction function--- With tensor caching optimization
   std::vector<std::vector<double>> TFLoaderMLP::PredictBatch(
     const std::vector<std::array<double, 3>>& positions)
   {
@@ -129,26 +144,47 @@ namespace phot {
       return {};
     }
 
+    // REMOVED: Old code that created new tensors every call
     // Define input tensors with shape (batch_size, 1)
-    tensorflow::Tensor pos_x(tensorflow::DT_FLOAT, tensorflow::TensorShape({batch_size, 1}));
-    tensorflow::Tensor pos_y(tensorflow::DT_FLOAT, tensorflow::TensorShape({batch_size, 1}));
-    tensorflow::Tensor pos_z(tensorflow::DT_FLOAT, tensorflow::TensorShape({batch_size, 1}));
+    // tensorflow::Tensor pos_x(tensorflow::DT_FLOAT, tensorflow::TensorShape({batch_size, 1}));
+    // tensorflow::Tensor pos_y(tensorflow::DT_FLOAT, tensorflow::TensorShape({batch_size, 1}));
+    // tensorflow::Tensor pos_z(tensorflow::DT_FLOAT, tensorflow::TensorShape({batch_size, 1}));
 
-    auto dst_x = pos_x.flat<float>().data();
-    auto dst_y = pos_y.flat<float>().data();
-    auto dst_z = pos_z.flat<float>().data();
 
+    // ADDED: Reuse cached tensors, only reallocate if batch size changed
+    // This prevents TensorFlow from accumulating tensor memory across events
+    // Most batches are 50k deposits, so this rarely reallocates after first batch
+    if (batch_size != cached_batch_size) {
+      cached_pos_x = tensorflow::Tensor(tensorflow::DT_FLOAT, 
+					tensorflow::TensorShape({batch_size, 1}));
+      cached_pos_y = tensorflow::Tensor(tensorflow::DT_FLOAT, 
+					tensorflow::TensorShape({batch_size, 1}));
+      cached_pos_z = tensorflow::Tensor(tensorflow::DT_FLOAT, 
+					tensorflow::TensorShape({batch_size, 1}));
+      cached_batch_size = batch_size;
+      std::cout << "TFLoaderMLP: Allocated tensors for batch size " << batch_size << std::endl;
+    }
+
+    // MODIFIED: Use cached tensors instead of local tensors
+    auto dst_x = cached_pos_x.flat<float>().data();
+    auto dst_y = cached_pos_y.flat<float>().data();
+    auto dst_z = cached_pos_z.flat<float>().data();
+    
     // Fill input tensors
     for (int i = 0; i < batch_size; ++i) {
       dst_x[i] = static_cast<float>(positions[i][0]);
       dst_y[i] = static_cast<float>(positions[i][1]);
       dst_z[i] = static_cast<float>(positions[i][2]);
     }
-
-    // Prepare input pair list
+    
+    // MODIFIED: Use cached tensors in inputs
+    // Prepare for inputs
     std::vector<std::pair<std::string, tensorflow::Tensor>> inputs = {
-      {InputsName[0], pos_x}, {InputsName[1], pos_y}, {InputsName[2], pos_z}};
-
+      {InputsName[0], cached_pos_x},   // Changed from pos_x
+      {InputsName[1], cached_pos_y},   // Changed from pos_y
+      {InputsName[2], cached_pos_z}    // Changed from pos_z
+    };
+    
     // Outputs
     std::vector<tensorflow::Tensor> outputs;
 
@@ -158,10 +194,10 @@ namespace phot {
       std::cerr << "TFLoaderMLP::PredictBatch Error: " << status.ToString() << std::endl;
       return {};
     }
-
+    
     // Parse output
     const tensorflow::Tensor& output_tensor = outputs[0];
-
+    
     // Check output shape: should be (batch_size, num_channels)
     if (output_tensor.dims() != 2) {
       std::cerr << "TFLoaderMLP::PredictBatch Error: Output tensor has wrong shape." << std::endl;
@@ -175,11 +211,11 @@ namespace phot {
       std::cerr << "TFLoaderMLP::PredictBatch Error: Output batch size mismatch." << std::endl;
       return {};
     }
-
+    
     // Prepare the output vector
     std::vector<std::vector<double>> predictions;
     predictions.resize(batch_size);
-
+    
     auto output_data = output_tensor.flat<float>().data();
 
     for (int i = 0; i < batch_size; ++i) {


### PR DESCRIPTION
Performance Optimization for PDFastSimANN
- **Execution time**: ~45 minutes → 2.5 minutes (18x speedup)
- **Memory usage**: ~52 GB → 7.4 GB (7x reduction)

Changes Made
1. Batch Processing Implementation
- Modified `PDFastSimANN_module.cc` to process photons in batches
- Applied performance optimizations matching PDFastSimPAR approach

2. TensorFlow Tensor Caching
- Added tensor caching to `TFLoaderMLP` to reuse tensors across batches
- Reduced TensorFlow tensor allocations from ~255 to ~10 per 5-event job
- Added member variables: `cached_pos_x`, `cached_pos_y`, `cached_pos_z`, `cached_batch_size`
- Modified `PredictBatch()` to check batch size and reuse cached tensors
- Updated `CloseSession()` to properly clear cached tensors

3.  Testing
Tested with PDVD cosmic ray simulations showing dramatic improvements in both execution time and memory footprint.