### PR TITLE
Changes applied in Spack package build process that need to be made for use with spack mpd

### DIFF
--- a/larsimdnn/PhotonPropagation/CMakeLists.txt
+++ b/larsimdnn/PhotonPropagation/CMakeLists.txt
@@ -18,7 +18,12 @@ if (TensorFlow_FOUND)
     cetlib_except::cetlib_except
     CLHEP::Random
   )
-
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
+      CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12.5")
+    # GCC 12.5 (and above) aggressively/spuriously warns about array-bounds issues.
+    target_compile_options(larsimdnn_PhotonPropagation_PDFastSimANN_module
+                         PRIVATE "-Wno-error=sign-compare")
+  endif()
   add_subdirectory(TFLoaderTools)
 endif()
 

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/CMakeLists.txt
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/CMakeLists.txt
@@ -16,6 +16,15 @@ cet_build_plugin(TFLoaderMLP lar::TFLoaderTool
   TensorFlow::framework
 )
 
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
+      CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12.5")
+    # GCC 12.5 (and above) aggressively/spuriously warns about array-bounds issues.
+    target_compile_options(TFLoaderTool
+                         PRIVATE "-Wno-error=sign-compare;")
+    target_compile_options(larsimdnn_PhotonPropagation_TFLoaderTools_TFLoaderMLP_tool
+                         PRIVATE "-Wno-error=sign-compare;")
+  endif()
+
 install_headers()
 install_fhicl()
 install_source()

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoader.h
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoader.h
@@ -12,8 +12,10 @@
 #include <string>
 #include <vector>
 
+#include "tensorflow/cc/saved_model/bundle_v2.h"
+#include "tensorflow/cc/saved_model/constants.h"
 #include "tensorflow/cc/saved_model/loader.h"
-#include "tensorflow/cc/saved_model/tag_constants.h"
+
 
 namespace phot {
 

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoader.h
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoader.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-#include "tensorflow/cc/saved_model/bundle_v2.h"
 #include "tensorflow/cc/saved_model/constants.h"
 #include "tensorflow/cc/saved_model/loader.h"
 

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoader.h
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoader.h
@@ -16,7 +16,6 @@
 #include "tensorflow/cc/saved_model/constants.h"
 #include "tensorflow/cc/saved_model/loader.h"
 
-
 namespace phot {
 
   class TFLoader {

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoader.h
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoader.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-#include "tensorflow/cc/saved_model/constants.h"
 #include "tensorflow/cc/saved_model/loader.h"
 
 namespace phot {

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP_tool.cc
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP_tool.cc
@@ -41,8 +41,11 @@ namespace phot {
     //Load SavedModel
     modelbundle = new tensorflow::SavedModelBundleLite();
 
-    status = tensorflow::LoadSavedModel(
-      tensorflow::SessionOptions(), tensorflow::RunOptions(), GraphFileWithPath, {"serve"}, modelbundle);
+    status = tensorflow::LoadSavedModel(tensorflow::SessionOptions(),
+                                        tensorflow::RunOptions(),
+                                        GraphFileWithPath,
+                                        {"serve"},
+                                        modelbundle);
 
     if (!status.ok()) {
       throw cet::exception("TFLoaderMLP")

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP_tool.cc
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP_tool.cc
@@ -44,7 +44,7 @@ namespace phot {
     status = tensorflow::LoadSavedModel(tensorflow::SessionOptions(),
                                         tensorflow::RunOptions(),
                                         GraphFileWithPath,
-                                        {tensorflow::kSavedModelTagServe},
+                                        {},
                                         modelbundle);
 
     if (!status.ok()) {

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP_tool.cc
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP_tool.cc
@@ -42,7 +42,7 @@ namespace phot {
     modelbundle = new tensorflow::SavedModelBundleLite();
 
     status = tensorflow::LoadSavedModel(
-      tensorflow::SessionOptions(), tensorflow::RunOptions(), GraphFileWithPath, {}, modelbundle);
+      tensorflow::SessionOptions(), tensorflow::RunOptions(), GraphFileWithPath, {"serve"}, modelbundle);
 
     if (!status.ok()) {
       throw cet::exception("TFLoaderMLP")

--- a/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP_tool.cc
+++ b/larsimdnn/PhotonPropagation/TFLoaderTools/TFLoaderMLP_tool.cc
@@ -41,11 +41,8 @@ namespace phot {
     //Load SavedModel
     modelbundle = new tensorflow::SavedModelBundleLite();
 
-    status = tensorflow::LoadSavedModel(tensorflow::SessionOptions(),
-                                        tensorflow::RunOptions(),
-                                        GraphFileWithPath,
-                                        {},
-                                        modelbundle);
+    status = tensorflow::LoadSavedModel(
+      tensorflow::SessionOptions(), tensorflow::RunOptions(), GraphFileWithPath, {}, modelbundle);
 
     if (!status.ok()) {
       throw cet::exception("TFLoaderMLP")


### PR DESCRIPTION
Also changes to Tensorflow includes that were deprecated in 2.15 and removed in 2.17.